### PR TITLE
Added AUR release.

### DIFF
--- a/src/components/Download.astro
+++ b/src/components/Download.astro
@@ -104,7 +104,7 @@ import { Icon } from "astro-icon/components";
             },
             "arch": {
                 "name": "AUR | Arch based distros",
-                "description": "There are multiple versions of winboat on AUR, we recommend using the bin version, as it doesn't require compiling the app from scratch. All versions of WinBoat on AUR are maintained by the community, and are not affiliated with the WinBoat team. Use at your own risk.",
+                "description": "There are multiple versions of WinBoat on AUR, we recommend using the bin version, as it doesn't require compiling the app from scratch. All versions of WinBoat on AUR are maintained by the community, and are not affiliated with the WinBoat team. Use at your own risk.",
                 "url": "https://aur.archlinux.org/packages/winboat-bin",
                 "download": "Download from AUR"
             }


### PR DESCRIPTION
There are multiple versions of the app on AUR, and a big chunk of the Linux userbase uses Arch-based distros. As such, I thought it was rather important to add the AUR version to the website.